### PR TITLE
Fixing Makefile setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,15 +22,15 @@ uv:
 ## Installs Python dependencies with uv
 .PHONY: requirements
 requirements:
+	uv build
 	uv sync
-	uv pip install -e .
 
 
 ## Install Jupyter dependencies
 .PHONY: requirements-nb
 requirements-nb:
+	uv build
 	uv sync --extra nb
-	uv pip install -e .
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,16 @@ PYTHON_INTERPRETER = python
 # COMMANDS                                                                      #
 #################################################################################
 
+## Installs uv
+.PHONY: uv
+uv:
+	$(PYTHON_INTERPRETER) -m pip install --upgrade pip
+	$(PYTHON_INTERPRETER) -m pip install uv
 
-## Install Python dependencies
+
+
+
+## Installs Python dependencies with uv
 .PHONY: requirements
 requirements:
 	uv sync

--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ This project uses **uv** as the package and environment manager, along with a `p
 
 ### **1. Install uv**
 
-If you don’t have `uv` installed:
+If you don’t have `uv` installed, run the following command in project root:
 
 ```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh
+make uv
 ```
 
 ### **2. Create & activate the environment**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=42"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "civicpulse-ml-dev"
 version = "0.1.0"

--- a/uv.lock
+++ b/uv.lock
@@ -222,7 +222,7 @@ wheels = [
 [[package]]
 name = "civicpulse-ml-dev"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "dotenv" },
     { name = "easyocr" },


### PR DESCRIPTION
1. Bugs were observed that prevented importing the project package civicpulseML from project root. These were resolved by adding lines below to the top of `pyproject.toml`, allowing `uv build` to download a build of the package in `src\` that can be imported and used by deployment services.:-
```toml
[build-system]
requires = ["setuptools>=42"]
build-backend = "setuptools.build_meta"
```

2. `make uv` command to install uv from PyPI.